### PR TITLE
flac tags - don't concatenate artist

### DIFF
--- a/aigpy/tagHelper.py
+++ b/aigpy/tagHelper.py
@@ -153,8 +153,8 @@ class TagTool(object):
             self._handle.add_tags()
         self._handle.tags['title'] = self.title
         self._handle.tags['album'] = self.album
-        self._handle.tags['albumartist'] = __tryList__(self.albumartist)
-        self._handle.tags['artist'] = __tryList__(self.artist)
+        self._handle.tags['albumartist'] = self.albumartist
+        self._handle.tags['artist'] = self.artist
         self._handle.tags['copyright'] = __tryStr__(self.copyright)
         self._handle.tags['tracknumber'] = str(self.tracknumber)
         self._handle.tags['tracktotal'] = str(self.totaltrack)


### PR DESCRIPTION
FLAC tag fields "Artist" and "Album Artist" support multiple entries ([relevant spec](https://xiph.org/vorbis/doc/v-comment.html#implications)). 
Don't combine multiple artists into a single string to improve support with many different media playing applications.

fixes #4 and at least one issue in https://github.com/yaronzz/Tidal-Media-Downloader
also matches behavior of https://github.com/yaronzz/Tidal-Media-Downloader-PRO